### PR TITLE
Add token label modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,22 @@
     </div>
   </div>
 </div>
+
+<div id="token-label-modal" class="modal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2>Token Label</h2>
+      <span class="close" id="token-label-modal-close">&times;</span>
+    </div>
+    <div class="modal-body">
+      <input type="text" id="token-label-input" class="form-control" placeholder="Enter label (optional)">
+    </div>
+    <div class="modal-footer">
+      <button id="token-label-confirm" class="btn btn-primary btn-sm">Add Token</button>
+      <button id="token-label-cancel" class="btn btn-secondary btn-sm">Cancel</button>
+    </div>
+  </div>
+</div>
 <!-- partial -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="./script.js"></script>


### PR DESCRIPTION
## Summary
- implement a modal for token labels rather than using `prompt`
- hook modal events in script to add tokens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875be184da8832f973017604c0664f0