### PR TITLE
Add Material icons for tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Hex Map Viewer</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="./style.css">
 
 </head>
@@ -147,6 +148,13 @@
       <span class="close" id="token-label-modal-close">&times;</span>
     </div>
     <div class="modal-body">
+      <select id="token-icon-select" class="form-select mb-2">
+        <option value="">-- None --</option>
+        <option value="star">star</option>
+        <option value="flag">flag</option>
+        <option value="person">person</option>
+        <option value="location_on">location_on</option>
+      </select>
       <input type="text" id="token-label-input" class="form-control" placeholder="Enter label (optional)">
     </div>
     <div class="modal-footer">

--- a/script.js
+++ b/script.js
@@ -36,6 +36,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const tokenLabelModal = document.getElementById('token-label-modal');
     const tokenLabelModalClose = document.getElementById('token-label-modal-close');
     const tokenLabelInput = document.getElementById('token-label-input');
+    const tokenIconSelect = document.getElementById('token-icon-select');
     const tokenLabelConfirm = document.getElementById('token-label-confirm');
     const tokenLabelCancel = document.getElementById('token-label-cancel');
     
@@ -177,7 +178,8 @@ document.addEventListener('DOMContentLoaded', function() {
                         x: t.x,
                         y: t.y,
                         color: t.color,
-                        label: t.label || ''
+                        label: t.label || '',
+                        icon: t.icon || ''
                     }));
                 }
                 
@@ -759,6 +761,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 ctx.stroke();
             }
 
+            if (token.icon) {
+                ctx.font = `${hexSize * 0.8}px \"Material Symbols Outlined\"`;
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillStyle = 'white';
+                ctx.fillText(token.icon, token.x, token.y);
+            }
+
             if (token.label) {
                 ctx.font = '12px Arial';
                 ctx.textAlign = 'center';
@@ -1193,6 +1203,7 @@ document.addEventListener('DOMContentLoaded', function() {
         pendingTokenPos = { x: worldX, y: worldY };
 
         tokenLabelInput.value = '';
+        if (tokenIconSelect) tokenIconSelect.value = '';
         tokenLabelModal.style.display = 'block';
         tokenLabelInput.focus();
     }
@@ -1201,11 +1212,13 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!pendingTokenPos) return;
 
         const label = tokenLabelInput.value.trim();
+        const icon = tokenIconSelect ? tokenIconSelect.value : '';
         const newToken = {
             x: pendingTokenPos.x,
             y: pendingTokenPos.y,
             color: tokenColor,
-            label: label
+            label: label,
+            icon: icon
         };
 
         tokens.push(newToken);
@@ -1452,7 +1465,8 @@ document.addEventListener('DOMContentLoaded', function() {
                         x: t.x,
                         y: t.y,
                         color: t.color,
-                        label: t.label || ''
+                        label: t.label || '',
+                        icon: t.icon || ''
                     }));
                 }
                 

--- a/style.css
+++ b/style.css
@@ -405,3 +405,10 @@ textarea#export-json {
         flex-basis: 100%;
     }
 }
+
+.material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 48;
+    font-size: inherit;
+    line-height: 1;
+}


### PR DESCRIPTION
## Summary
- load Material Symbols from Google Fonts
- allow selecting an icon when creating a token
- store a new `icon` field on tokens and render it on the canvas
- persist icons when exporting, importing and saving state
- add minimal CSS rule for Material Symbols

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875c2fe8084832fa04ddba340cb46b3