### PR TITLE
Add token notes tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ HexPlora is a web-based viewer for tabletop-style maps. It overlays a hexagonal 
 - Customizable appearance for fog of war and grid lines.
 - Reveal/hide mode for managing fog of war directly on the canvas.
 - Add, move and clear tokens with customizable colors, labels and notes.
+- Hover over a token for a second to view its notes in a tooltip.
 - Zoom and pan support with mouse wheel and drag controls.
 - Import/export of the full map state (tokens with labels, notes, revealed hexes, settings).
 - Toggleable header and optional debug view.
@@ -46,7 +47,8 @@ The top header contains controls for map settings and appearance:
 A row of buttons below the settings provides quick actions:
 
 - **Mode: Reveal/Hide** – switches between revealing or hiding hexes.
- - **Add Token** – enables token placement. A modal lets you set the token label, color, icon and optional notes. Existing tokens can be dragged or cleared.
+- **Add Token** – enables token placement. A modal lets you set the token label, color, icon and optional notes. Existing tokens can be dragged or cleared.
+- **Hover Tokens** – pausing the cursor over a token for a second shows its notes.
 - **Reset View** – resets zoom and panning. **Reset Fog** hides all revealed hexes.
 - **Clear Tokens** – removes all tokens from the map.
 - **Toggle Debug** – shows internal debug information.

--- a/index.html
+++ b/index.html
@@ -105,10 +105,11 @@
   <button id="toggle-header-btn" class="btn btn-primary btn-sm"><i class="bi bi-caret-up-fill"></i></button>
 </div>
 
-<div class="map-container" id="map-container">
-  <canvas id="map-canvas"></canvas>
-  <div class="loading" id="loading">Loading map...</div>
-</div>
+  <div class="map-container" id="map-container">
+    <canvas id="map-canvas"></canvas>
+    <div class="loading" id="loading">Loading map...</div>
+    <div id="token-tooltip" class="token-tooltip"></div>
+  </div>
 
 <div id="info-bar">
   <span id="zoom-display">Zoom: 100%</span>

--- a/style.css
+++ b/style.css
@@ -220,6 +220,21 @@ input[type="range"] {
 .map-container.token-dragging canvas { cursor: move; }
 .map-container.token-hover canvas { cursor: pointer; } /* When over a token */
 
+/* Tooltip for token notes */
+.token-tooltip {
+    position: absolute;
+    max-width: 200px;
+    background-color: rgba(0, 0, 0, 0.85);
+    color: #fff;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    z-index: 1010;
+    pointer-events: none;
+    display: none;
+    white-space: pre-wrap;
+}
+
 
 canvas {
     display: block; /* Remove extra space below canvas */


### PR DESCRIPTION
## Summary
- show token notes when hovering a token for a second
- add tooltip styling and element
- document token hover feature in README

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6875ca155ae0832faa1ae1037aa60bce