### PR TITLE
Introduce centralized state module

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+import { state } from './state.js';
+
 document.addEventListener('DOMContentLoaded', function() {
     // DOM elements
     const mapCanvas = document.getElementById('map-layer');
@@ -121,6 +123,43 @@ document.addEventListener('DOMContentLoaded', function() {
     // Render loop state
     let needsRedraw = false;
 
+    function syncStore() {
+        Object.assign(state, {
+            hexSize,
+            offsetX,
+            offsetY,
+            columnCount,
+            rowCount,
+            orientation,
+            mapScale,
+            hexes,
+            revealedHexes,
+            mapImage,
+            zoomLevel,
+            panX,
+            panY,
+            isPanning,
+            lastMouseX,
+            lastMouseY,
+            fogColor,
+            fogOpacity,
+            gridColor,
+            gridThickness,
+            tokenColor,
+            tokens,
+            isDraggingToken,
+            selectedTokenIndex,
+            isAddingToken,
+            isRemovingToken,
+            pendingTokenPos,
+            editingTokenIndex,
+            undoStack,
+            redoStack,
+            needsRedraw,
+            revealMode
+        });
+    }
+
     function hexToRgb(hex) {
         hex = hex.replace('#', '');
         if (hex.length === 3) {
@@ -145,6 +184,7 @@ document.addEventListener('DOMContentLoaded', function() {
         updateInputFields();
         setupEventListeners();
         loadMap();
+        syncStore();
         updateUndoRedoButtons();
         log('App initialized');
     }
@@ -202,6 +242,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }));
                 }
                 
+                syncStore();
                 log('Loaded saved state');
             }
         } catch (error) {
@@ -889,11 +930,13 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         saveState();
+        syncStore();
         requestRedraw();
     }
 
     function pushHistory() {
         undoStack.push(snapshotState());
+        syncStore();
         if (undoStack.length > 100) undoStack.shift();
         redoStack = [];
         updateUndoRedoButtons();
@@ -1631,6 +1674,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     
     function saveState() {
+        syncStore();
         try {
             const settings = {
                 hexSize: hexSize,

--- a/state.js
+++ b/state.js
@@ -1,0 +1,65 @@
+export const data = {
+    hexSize: 40,
+    offsetX: 0,
+    offsetY: 0,
+    columnCount: 20,
+    rowCount: 15,
+    orientation: 'pointy',
+    mapScale: 100,
+    hexes: [],
+    revealedHexes: {},
+    mapImage: null,
+    zoomLevel: 1,
+    panX: 0,
+    panY: 0,
+    isPanning: false,
+    lastMouseX: 0,
+    lastMouseY: 0,
+    fogColor: '#225522',
+    fogOpacity: 0.85,
+    gridColor: '#FFFFFF',
+    gridThickness: 1,
+    tokenColor: '#FF0000',
+    tokens: [],
+    isDraggingToken: false,
+    selectedTokenIndex: -1,
+    isAddingToken: false,
+    isRemovingToken: false,
+    pendingTokenPos: null,
+    editingTokenIndex: -1,
+    undoStack: [],
+    redoStack: [],
+    needsRedraw: false,
+    revealMode: true
+};
+
+const observers = new Set();
+
+function notify(key, value, oldValue) {
+    observers.forEach(cb => cb(key, value, oldValue));
+}
+
+export const state = new Proxy(data, {
+    set(target, prop, value) {
+        const oldValue = target[prop];
+        target[prop] = value;
+        notify(prop, value, oldValue);
+        return true;
+    },
+    get(target, prop) {
+        return target[prop];
+    }
+});
+
+export function getState(key) {
+    return key ? state[key] : state;
+}
+
+export function setState(key, value) {
+    state[key] = value;
+}
+
+export function subscribe(callback) {
+    observers.add(callback);
+    return () => observers.delete(callback);
+}


### PR DESCRIPTION
## Summary
- add a `state.js` module that stores map/UI data and supports observers
- provide a `syncStore` helper in `script.js` to push local variables to the shared state
- update initialization, load/save logic and history helpers to keep the store current

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876803835e0832f9b1f71ccadd3252d