### PR TITLE
Introduce spatial indexing for token and hex lookup

### DIFF
--- a/spatialIndex.js
+++ b/spatialIndex.js
@@ -1,0 +1,47 @@
+export class SpatialHashGrid {
+    constructor(cellSize = 100) {
+        this.cellSize = cellSize;
+        this.cells = new Map();
+    }
+
+    clear() {
+        this.cells.clear();
+    }
+
+    _key(cx, cy) {
+        return `${cx},${cy}`;
+    }
+
+    _cellsForBounds(bounds) {
+        const cxMin = Math.floor(bounds.xMin / this.cellSize);
+        const cyMin = Math.floor(bounds.yMin / this.cellSize);
+        const cxMax = Math.floor(bounds.xMax / this.cellSize);
+        const cyMax = Math.floor(bounds.yMax / this.cellSize);
+        const cells = [];
+        for (let cx = cxMin; cx <= cxMax; cx++) {
+            for (let cy = cyMin; cy <= cyMax; cy++) {
+                cells.push(this._key(cx, cy));
+            }
+        }
+        return cells;
+    }
+
+    insert(obj, bounds) {
+        const keys = this._cellsForBounds(bounds);
+        for (const key of keys) {
+            if (!this.cells.has(key)) {
+                this.cells.set(key, new Set());
+            }
+            this.cells.get(key).add(obj);
+        }
+    }
+
+    queryPoint(x, y) {
+        const cx = Math.floor(x / this.cellSize);
+        const cy = Math.floor(y / this.cellSize);
+        const key = this._key(cx, cy);
+        const set = this.cells.get(key);
+        if (!set) return [];
+        return Array.from(set);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `SpatialHashGrid` module
- build spatial indexes for hexes and tokens
- query indexes when looking up hexes and tokens
- rebuild token index whenever tokens move

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687685c6b5d8832f854a816398c1fbf4