### PR TITLE
Fix hidden map layer by using transparent canvas overlays

### DIFF
--- a/style.css
+++ b/style.css
@@ -238,7 +238,7 @@ input[type="range"] {
 
 canvas {
     display: block; /* Remove extra space below canvas */
-    background-color: #2d3748; /* Fallback bg for canvas area */
+    background-color: transparent;
     /* Position/Transform will be handled by JS for pan/zoom */
     /* width/height set by JS */
 }
@@ -249,7 +249,11 @@ canvas {
     left: 0;
 }
 
-#map-layer { z-index: 0; pointer-events: none; }
+#map-layer {
+    background-color: #2d3748;
+    z-index: 0;
+    pointer-events: none;
+}
 #grid-layer { z-index: 1; pointer-events: none; }
 #token-layer { z-index: 2; }
 


### PR DESCRIPTION
## Summary
- make all canvases transparent by default so stacked layers stay visible
- set `#map-layer` fallback color to maintain the dark background when no map is loaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68768e2275d0832fbeb00faa435e9a90