### PR TITLE
Fix token index rebuild memory leak

### DIFF
--- a/script.js
+++ b/script.js
@@ -698,7 +698,14 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function rebuildTokenIndex() {
-        tokenIndex = new SpatialHashGrid(hexSize * 2);
+        if (tokenIndex) {
+            // Reuse the existing spatial grid to avoid leaking old references
+            tokenIndex.clear();
+            tokenIndex.cellSize = hexSize * 2;
+        } else {
+            tokenIndex = new SpatialHashGrid(hexSize * 2);
+        }
+
         for (let i = 0; i < tokens.length; i++) {
             const t = tokens[i];
             t._index = i;


### PR DESCRIPTION
## Summary
- reuse existing token spatial grid when rebuilding the token index

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687694420094832fa5cf91b799430e8a