### PR TITLE
Fix spatial hash key collisions

### DIFF
--- a/spatialIndex.js
+++ b/spatialIndex.js
@@ -9,7 +9,13 @@ export class SpatialHashGrid {
     }
 
     _key(cx, cy) {
-        return `${cx},${cy}`;
+        // Encode coordinates using a Cantor pairing on unsigned values to
+        // avoid any chance of collisions with negative numbers.
+        const encode = (n) => (n >= 0 ? 2 * n : -2 * n - 1);
+        const x = encode(cx);
+        const y = encode(cy);
+        const pair = ((x + y) * (x + y + 1)) / 2 + y;
+        return pair.toString();
     }
 
     _cellsForBounds(bounds) {


### PR DESCRIPTION
## Summary
- make key generation in `spatialIndex.js` robust using Cantor pairing to avoid theoretical collisions with negative coordinates

## Testing
- `node - <<'NODE'
const { SpatialHashGrid } = await import('./spatialIndex.js');
const grid = new SpatialHashGrid(1);
console.log(grid._key(-1, -1));
console.log(grid._key(-1, 0));
console.log(grid._key(0, -1));
console.log(grid._key(0, 0));
console.log(grid._key(1,1));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68769e7daab8832fbc6b0306ba6b4d2a