### PR TITLE
Fix tooltip timer cleanup

### DIFF
--- a/script.js
+++ b/script.js
@@ -1279,6 +1279,10 @@ document.addEventListener('DOMContentLoaded', function() {
             mapContainer.classList.add('token-hover');
 
             if (tokenIndex !== hoveredTokenIndex) {
+                if (tooltipTimer) {
+                    clearTimeout(tooltipTimer);
+                    tooltipTimer = null;
+                }
                 hideTooltip();
                 hoveredTokenIndex = tokenIndex;
                 if (tokens[tokenIndex].notes) {
@@ -1289,6 +1293,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             tokenTooltip.style.left = `${event.clientX - rect.left + 15}px`;
                             tokenTooltip.style.top = `${event.clientY - rect.top + 15}px`;
                             tokenTooltip.style.display = 'block';
+                            tooltipTimer = null;
                         }
                     }, 1000);
                 }


### PR DESCRIPTION
## Summary
- ensure previous tooltip timers are cleared before starting a new one
- reset `tooltipTimer` after displaying tooltip

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68769f4e5330832fa0fe30a4e37449ee