### PR TITLE
Add global error handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,6 +167,39 @@
 </div>
 <!-- partial -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+
+  <!-- Global error handling -->
+  <script>
+    window.addEventListener('error', function(event) {
+      console.error('Global error:', event.message, event.error);
+      if (window.showStatus) {
+        showStatus('Unexpected error: ' + event.message, 'error');
+      } else {
+        var el = document.getElementById('status-indicator');
+        if (el) {
+          el.style.backgroundColor = '#e53e3e';
+          el.textContent = 'Unexpected error: ' + event.message;
+          el.style.display = 'inline-block';
+        }
+      }
+    });
+
+    window.addEventListener('unhandledrejection', function(event) {
+      var msg = event.reason && event.reason.message ? event.reason.message : event.reason;
+      console.error('Unhandled promise rejection:', event.reason);
+      if (window.showStatus) {
+        showStatus('Unhandled promise: ' + msg, 'error');
+      } else {
+        var el = document.getElementById('status-indicator');
+        if (el) {
+          el.style.backgroundColor = '#e53e3e';
+          el.textContent = 'Unhandled promise: ' + msg;
+          el.style.display = 'inline-block';
+        }
+      }
+    });
+  </script>
+
   <script type="module" src="./script.js"></script>
 
 </body>

--- a/script.js
+++ b/script.js
@@ -421,9 +421,23 @@ document.addEventListener('DOMContentLoaded', function() {
         
         // Copy JSON to clipboard
         copyJsonBtn.addEventListener('click', function() {
-            exportJsonTextarea.select();
-            navigator.clipboard.writeText(exportJsonTextarea.value);
-            showStatus('Copied to clipboard!', 'success');
+            try {
+                exportJsonTextarea.select();
+                var promise = navigator.clipboard.writeText(exportJsonTextarea.value);
+                if (promise && typeof promise.then === 'function') {
+                    promise.then(() => {
+                        showStatus('Copied to clipboard!', 'success');
+                    }).catch(err => {
+                        console.error('Clipboard error:', err);
+                        showStatus('Failed to copy to clipboard', 'error');
+                    });
+                } else {
+                    showStatus('Copied to clipboard!', 'success');
+                }
+            } catch (err) {
+                console.error('Clipboard error:', err);
+                showStatus('Failed to copy to clipboard', 'error');
+            }
         });
         
         // Download JSON file


### PR DESCRIPTION
## Summary
- catch uncaught errors with global event listeners in `index.html`
- wrap clipboard export in try/catch to avoid crashes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876a119bd0c832f86cc4bf2fff671c2